### PR TITLE
Added mtwebster's dev-setup changes

### DIFF
--- a/usr/bin/mint-dev-build
+++ b/usr/bin/mint-dev-build
@@ -2,8 +2,16 @@
 
 import sys
 import os
+from gi.repository import GLib
 
-user_home = os.path.expanduser('~')
+GROUP = "Mint Development Tools"
+SANDBOX_PATH = "DevRoot"
+SANDBOX_NAME = "RootDisplayName"
+THREADS = "Threads"
+
+SETTINGS_PATH = "%s/mint-dev-tools" % GLib.get_user_config_dir()
+
+settings = None
 
 
 class Project:
@@ -13,7 +21,10 @@ class Project:
         self.subprojects = subprojects
 
 projects = []
-projects.append(Project("Cinnamon (all sub-projects)", ["cjs", "cinnamon-desktop", "cinnamon-menus", "cinnamon-translations", "cinnamon-session", "cinnamon-settings-daemon", "cinnamon-control-center", "cinnamon-screensaver", "muffin", "cinnamon", "nemo"]))
+projects.append(Project("Cinnamon (all sub-projects)", ["cinnamon-translations", "cinnamon-desktop", "cinnamon-menus",
+                                                        "cinnamon-session", "cinnamon-settings-daemon", "cinnamon-screensaver", "cjs",
+                                                        "cinnamon-control-center", "muffin",
+                                                        "cinnamon", "nemo"]))
 projects.append(Project("cjs", ["cjs"]))
 projects.append(Project("cinnamon-desktop", ["cinnamon-desktop"]))
 projects.append(Project("cinnamon-menus", ["cinnamon-menus"]))
@@ -34,19 +45,26 @@ for simple_project in simple_projects:
 projects = sorted(projects, key=lambda x: x.name, reverse=False)
 
 ## Check mint-dev-setup ran successfully
-if not os.path.exists("%s/.mint-dev-setup" % user_home):
+if not os.path.exists(SETTINGS_PATH):
     print("")
     print(" === ERROR ===")
     print("")
     print("Your development environment isn't set up properly. Please run mint-dev-setup.")
     sys.exit(1)
 
+settings = GLib.KeyFile.new()
+settings.load_from_file(SETTINGS_PATH, GLib.KeyFileFlags.KEEP_COMMENTS)
+
+root = settings.get_string(GROUP, SANDBOX_PATH)
+name = settings.get_string(GROUP, SANDBOX_NAME)
+threads = settings.get_integer(GROUP, THREADS)
+
 print("")
 print(" === WARNING ===")
 print("")
 print("This command does the following:")
-print("    - Deletes all build outputs your Sandbox (~/Sandbox/*_*)")
-print("    - Deletes the local version (along with any local changes) for the selected project(s) (~/Sandbox/<projectname>)")
+print("    - Deletes all build outputs in your Sandbox (~/%s/*_*)" % name)
+print("    - Deletes the local version (along with any local changes) for the selected project(s) (~/%s/<projectname>)" % name)
 print("    - Downloads and compiles the selected project(s) from Github's master branch(es)")
 print("    - Installs the packages produced by the compilation (and overrides local versions)")
 print("")
@@ -77,7 +95,7 @@ while selected_project is None:
     if index > 0 and index <= len(projects):
         selected_project = projects[index - 1]
 
-os.chdir("%s/Sandbox" % user_home)
+os.chdir(root)
 os.system("rm -f *_*")  # Remove all packages and build results
 
 for subproject in selected_project.subprojects:
@@ -108,7 +126,7 @@ for subproject in selected_project.subprojects:
     print("   ### Building %s" % subproject)
     print("   #######################################################################")
     print("")
-    os.system("dpkg-buildpackage")
+    os.system("dpkg-buildpackage -us -uc -j%d" % threads)
     print("")
     print("   #######################################################################")
     print("   ### Installing %s" % subproject)

--- a/usr/bin/mint-dev-setup
+++ b/usr/bin/mint-dev-setup
@@ -2,15 +2,38 @@
 
 import os
 import subprocess
+from gi.repository import GLib
+
+GROUP = "Mint Development Tools"
+SANDBOX_PATH = "DevRoot"
+SANDBOX_NAME = "RootDisplayName"
+THREADS = "Threads"
 
 USER_HOME = os.path.expanduser('~')
+SETTINGS_PATH = "%s/mint-dev-tools" % GLib.get_user_config_dir()
+
+settings = None
+settings = GLib.KeyFile.new()
+
+if os.path.exists(SETTINGS_PATH):
+    settings.load_from_file(SETTINGS_PATH, GLib.KeyFileFlags.KEEP_COMMENTS)
+
+print("")
+print("Enter the name for your development directory - it will be placed in your home folder.")
+print("")
+dir_name = input("Name of folder (press return to name it 'Sandbox'):  ")
+if dir_name == "":
+    dir_name = "Sandbox"
 
 ## Create Sandbox
-while not os.path.exists("%s/Sandbox" % USER_HOME):
+while not os.path.exists("%s/%s" % (USER_HOME, dir_name)):
     print("")
     print(" === CREATING A SANDBOX ===")
-    os.system("mkdir -p ~/Sandbox")
-    print("Your Sandbox was created in ~/Sandbox. This is where you'll do all your development.")
+    os.system("mkdir -p ~/%s" % dir_name)
+    print("Your sandbox was created in ~/%s. This is where you'll do all your development." % dir_name)
+
+settings.set_string(GROUP, SANDBOX_PATH, "%s/%s" % (USER_HOME, dir_name))
+settings.set_string(GROUP, SANDBOX_NAME, dir_name)
 
 ## Configure Git
 while not os.path.exists("%s/.gitconfig" % USER_HOME):
@@ -31,26 +54,35 @@ while not os.path.exists("%s/.ssh/id_rsa.pub" % USER_HOME):
     print("")
     os.system("cat ~/.ssh/id_rsa.pub")
 
-## Configure APT source repositories
-while not os.path.exists("/etc/apt/sources.list.d/official-source-repositories.list"):
-    print("")
-    print(" === SETTING UP APT SOURCE REPOSITORIES ===")
-    print("")
-    print("You need to tick the option to 'Enable source code repositories' in mintsources.")
-    input("Press ENTER to launch mintsources.")
-    os.system("mintsources")
+print("")
+print(" === REFRESHING APT CACHE ===")
+print("")
+input("Press ENTER to refresh the APT cache.")
+os.system("sudo apt-get update")
 
-## Refresh APT cache
-lsb_codename = subprocess.getoutput("lsb_release -cs").strip()
-while not os.path.exists("/var/lib/apt/lists/extra.linuxmint.com_dists_%s_main_source_Sources" % lsb_codename):
-    print("")
-    print(" === REFRESHING APT CACHE ===")
-    print("")
-    input("Press ENTER to refresh the APT cache.")
-    os.system("apt update")
+max_threads = int(subprocess.getoutput("cat /proc/cpuinfo | grep processor | wc -l")) + 1
 
-# We're all set, create a .mint-dev-tools so we know everything's fine
-os.system("touch %s/.mint-dev-setup" % USER_HOME)
+print("")
+print("Enter the maximum number of threads to use for compiling.")
+print("This has little effect on smaller projects, but can save a")
+print("a lot of time when compiling Cinnamon.")
+print("")
+print("Maximum recommended for this system: %d" % max_threads)
+print("")
+print("Using less threads will ensure your system remains more responsive")
+print("during compilation, at the cost of it potentially taking longer to complete.")
+print("")
+try:
+    max_threads_user = int(input("Enter the number of threads to use, or press return to use the maximum: "))
+except:
+    max_threads_user = max_threads
+print("")
+print("Compiling with %d threads" % max_threads_user)
+
+settings.set_integer(GROUP, THREADS, max_threads_user)
+
+# We're all set, save the settings file which has our sandbox path
+settings.save_to_file(SETTINGS_PATH)
 
 print("")
 print(" === ALL DONE ===")


### PR DESCRIPTION
specify sandbox folder during setup
specify # compilation threads during setup
enable build support for those two options
packages are built with the -us -uc options to disable signing

does not include the other build changes due to the dependency issues

credit: @mtwebster https://github.com/linuxmint/mint-dev-tools/pull/4

**Note:** mint-dev setup needs to be run again after installing this patch
