### PR TITLE
cinnamon-stats-tracker: Tail the log file while waiting

### DIFF
--- a/usr/bin/cinnamon-stats-tracker
+++ b/usr/bin/cinnamon-stats-tracker
@@ -56,7 +56,6 @@ def sleep(interval, output_file):
         now = time.monotonic()
         if not monitor.poll.poll(1):
             continue
-        print_and_save(output_file, "---------------------------------------------")
         print_and_save(output_file, monitor.get_log_line())
 
 def main_quit(notif):

--- a/usr/bin/cinnamon-stats-tracker
+++ b/usr/bin/cinnamon-stats-tracker
@@ -4,9 +4,16 @@ import os
 import psutil
 import subprocess
 import time
+import select
 gi.require_version('Gtk', '3.0')
 gi.require_version('Notify', '0.7')
 from gi.repository import Gtk, Gio, Notify
+
+monitor = None
+
+def print_and_save(output_file, data):
+    print(data)
+    output_file.write(data + "\n")
 
 class Monitor():
 
@@ -14,18 +21,25 @@ class Monitor():
         self.pid = subprocess.check_output('pidof cinnamon', encoding='UTF-8', shell=True).strip()
         self.process = psutil.Process(int(self.pid))
 
+        self.log = subprocess.Popen(["tail", "-f", "-n100", os.path.expanduser("~/.xsession-errors")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.poll = select.poll()
+        self.poll.register(self.log.stdout)
+
     def get_used_memory(self):
         # Used memory in MB
         mem = self.process.memory_info()
         memory = round(((mem.rss - mem.shared) / 1024 / 1024))
         return ("%d MB" % memory)
 
-    def get_start_logs(self):
-        # Start logs
-        logs = ""
-        with open(os.path.expanduser("~/.cinnamon/glass.log")) as log_file:
-            logs = log_file.read().strip()
-        return logs
+    def get_start_logs(self, output_file):
+        # Read the last 100 lines
+        i = 100
+        while (i > 0):
+            i -= 1
+            print_and_save(output_file, self.get_log_line())
+
+    def get_log_line(self):
+        return self.log.stdout.readline().decode("utf-8").strip()
 
     def get_cpu_time(self):
         # Used CPU time
@@ -34,14 +48,25 @@ class Monitor():
         t = time.strftime('%H:%M:%S', time.gmtime(used))
         return t
 
-def print_and_save(output_file, data):
-    print(data)
-    output_file.write(data + "\n")
+def sleep(interval, output_file):
+    now = 0
+    elapsed = time.monotonic()
+    # This is the same as time.sleep(int) but instead of sleeping it checks the log file.
+    while now - elapsed < interval:
+        now = time.monotonic()
+        if not monitor.poll.poll(1):
+            continue
+        print_and_save(output_file, "---------------------------------------------")
+        print_and_save(output_file, monitor.get_log_line())
+
+def main_quit(notif):
+    monitor.poll.unregister(monitor.log.stdout)
+    Gtk.main_quit()
 
 def show_stats(notif, action):
     subprocess.Popen(["xdg-open", os.path.expanduser("~/.cinnamon/stats.log")])
     notif.close()
-    Gtk.main_quit()
+    main_quit(None)
 
 if __name__ == '__main__':
 
@@ -60,13 +85,13 @@ if __name__ == '__main__':
         print_and_save(output_file, "  INITIAL STATS")
         print_and_save(output_file, "---------------------------------------------")
         print_and_save(output_file, "PID %s" % monitor.pid)
-        print_and_save(output_file, monitor.get_start_logs())
+        monitor.get_start_logs(output_file)
         print_and_save(output_file, "RAM: %s" % monitor.get_used_memory())
         print_and_save(output_file, "CPU time: %s" % monitor.get_cpu_time())
 
         if (measures > 0):
             for i in range(measures):
-                time.sleep(interval)
+                sleep(interval, output_file)
                 print_and_save(output_file, "---------------------------------------------")
                 print_and_save(output_file, "  AFTER %d minutes" % (round(interval/60) * (i+1)))
                 print_and_save(output_file, "---------------------------------------------")
@@ -76,6 +101,6 @@ if __name__ == '__main__':
     notification = Notify.Notification.new("Stats Tracker Finished", "The stats were successfully recorded in ~/.cinnamon/stats.log. You can now launch apps and use Cinnamon normally.", "cinnamon-symbolic")
     notification.add_action("action_show", "Show stats", show_stats)
     notification.set_urgency(Notify.Urgency.CRITICAL)
-    notification.connect("closed", Gtk.main_quit)
+    notification.connect("closed", main_quit)
     notification.show()
     Gtk.main()


### PR DESCRIPTION
This makes it so we can see updates to the log between stats updates, and other types of benchmarks can be included in stats.log, such as Clutter frame times.