### PR TITLE
mint-build: add options for prs, temp files, and copying debs

### DIFF
--- a/usr/bin/mint-build
+++ b/usr/bin/mint-build
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import tempfile
 import argparse
 
 def call(command):
@@ -50,19 +51,40 @@ def build(suffix):
     if os.path.exists("debian/changelog.orig"):
         call("mv debian/changelog.orig debian/changelog")
 
+def copy_debs(deb_dir):
+    print("")
+    print("   #######################################################################")
+    print("   ### Moving debs to %s" % deb_dir)
+    print("   #######################################################################")
+    print("")
+    os.makedirs(deb_dir, exist_ok=True)
+    os.system('cp ../*.deb %s' % deb_dir)
+
 parser = argparse.ArgumentParser(description='Build project')
 parser.add_argument("-i", "--install", action="store_true", help="Install built packages")
 parser.add_argument("-s", "--suffix", help="Version suffix", required=False)
-parser.add_argument("-g", "--git-repository", help="Git clone URL, or project name (for Mint projects on Github). Suffix with #tagname or #branchname to specify a branch or a tag to build from.", required=False)
+parser.add_argument("-g", "--git-repository", help="Git clone URL, or project name (for Mint projects on Github). Suffix with #tagname, #branchname or %%pullrequest to specify a branch, a tag, or a pull request to build from.", required=False)
+parser.add_argument("-t", "--temporary", action="store_true", help="Use a temporary directory for building")
+parser.add_argument("-d", "--deb-dir", help="Folder to copy debs to when building is complete. If this option is omitted, the generated debs will not be copied.", required=False)
 args = parser.parse_args()
 
 cwd = os.getcwd()
+temp_directory = None
+deb_dir = None
+if args.deb_dir is not None:
+    deb_dir = os.path.abspath(args.deb_dir)
 
 if args.git_repository is not None:
     project_url = args.git_repository
     tag_branch = None
+    pull_request = None
+
     if "#" in project_url:
         (project_url, tag_branch) = project_url.split("#")
+    elif "%" in project_url:
+        (project_url, pull_request) = project_url.split("%")
+        tag_branch = pull_request
+
     if "://" in project_url or "@" in project_url:
         project_name = project_url.split("/")[-1].replace(".git", "")
     else:
@@ -70,16 +92,26 @@ if args.git_repository is not None:
         project_name = project_url
         project_url = "https://github.com/linuxmint/%s.git" % project_name
     call("mkdir -p %s" % project_name)
-    os.chdir(project_name)
+
+    if args.temporary:
+        temp_directory = tempfile.TemporaryDirectory()
+        os.chdir(temp_directory.name)
+    else:
+        os.chdir(project_name)
+        if os.path.exists(project_name):
+            call("rm -rf '%s'" % project_name)
+
     print("")
     print("   #######################################################################")
     print("   ### Cloning %s (branch/tag: %s)" % (project_name, tag_branch))
     print("   #######################################################################")
     print("")
-    if os.path.exists(project_name):
-        call("rm -rf '%s'" % project_name)
     call("git clone %s" % project_url)
     os.chdir(project_name)
+
+    if pull_request is not None:
+        call("git fetch origin pull/%s/head:%s" % (pull_request, pull_request))
+
     if tag_branch is not None:
         call("git checkout %s" % tag_branch)
 
@@ -87,6 +119,8 @@ if os.path.exists('debian'):
     build(args.suffix)
     if args.install:
         install()
+    if deb_dir is not None:
+        copy_debs(deb_dir)
 else:
     for subdirectory in os.listdir("."):
         if os.path.isdir(subdirectory) and os.path.exists(os.path.join(subdirectory, "debian")):
@@ -94,6 +128,11 @@ else:
             build(args.suffix)
             if args.install:
                 install()
+            if deb_dir is not None:
+                copy_debs(deb_dir)
             os.chdir("..")
+
+if temp_directory is not None:
+    temp_directory.cleanup()
 
 os.chdir(cwd)


### PR DESCRIPTION
* The `-g` option now takes `%pullrequest` as an optional suffix in addition to `#branchname` and `#tagname` which already existed.

* The project can now be cloned and built in a temporary directory by passing the `-t` option. The tepmporary directory will be cleaned up on completion of the script. This is useful if you want to avoid conflicts with your existing sandbox, without having to clean up manually afterwards.

* The generated debs can now be copied to a separate folder by using the `-d <deb-dir>` option.