### PR TITLE
mint-check-translations: polib.py not found

### DIFF
--- a/usr/bin/mint-check-translations
+++ b/usr/bin/mint-check-translations
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # coding=utf-8
 import argparse
 import polib


### PR DESCRIPTION
linuxmint-devtools, downloaded in 12/2019: mint-check-translations didn't work.
After modifying the shebang to python3 the script now works properly. 

Many thanks to Odyseus for the tipp. erwn16