### PR TITLE
Recommend libxapp-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,6 @@ Depends: python3 (>= 3.3),
          ${misc:Depends},
          equivs,
          devscripts
-Recommends: gitk, gitg, git-buildpackage, meld, meson, sublime-text, devhelp, glade, regexxer, pyrenamer, d-feet, gdb, awf, gconf-editor, dconf-editor, gnome-dbg, devscripts, gnome-api-docs, valgrind, ccache, wininfo, perf, debuginfod
+Recommends: gitk, gitg, git-buildpackage, meld, meson, sublime-text, devhelp, glade, regexxer, pyrenamer, d-feet, gdb, awf, gconf-editor, dconf-editor, gnome-dbg, devscripts, gnome-api-docs, valgrind, ccache, wininfo, perf, debuginfod, libxapp-dev
 Description: A collection of tools to develop/compile Linux Mint projects
  All you need to develop/compile Linux Mint projects.


### PR DESCRIPTION
If libxapp-dev isn't installed, Glade is unable to show XAppStackSidebars.