### PR TITLE
Handle lone '%' translation strings without parser exceptions - fixes issue #28

### DIFF
--- a/usr/bin/mint-check-translations
+++ b/usr/bin/mint-check-translations
@@ -245,7 +245,7 @@ class Main:
             if issue_found:
                 self.add_issue_to_treeview(mo, mo.project, msgid, msgstr, res, mo.current_index)
             mo.current_index += 1
-            
+
     def check_entry(self, msgid, msgstr, is_plural=False, is_python=False):
         msgid = msgid.replace("%%", " ")
         msgstr = msgstr.replace("%%", " ")
@@ -331,7 +331,7 @@ class Main:
                                     break
             except Exception as e:
                 print("Error parsing msgstr at index %d: %s" % (idx, e))
-                
+
         for keyword in ["5%", "0%"]:
             if keyword in msgid:
                 # Ignore percentages

--- a/usr/bin/mint-check-translations
+++ b/usr/bin/mint-check-translations
@@ -245,7 +245,7 @@ class Main:
             if issue_found:
                 self.add_issue_to_treeview(mo, mo.project, msgid, msgstr, res, mo.current_index)
             mo.current_index += 1
-
+            
     def check_entry(self, msgid, msgstr, is_plural=False, is_python=False):
         msgid = msgid.replace("%%", " ")
         msgstr = msgstr.replace("%%", " ")
@@ -263,6 +263,11 @@ class Main:
                     if idx > 1 and msgid[idx-1] == " " and msgid[idx-2] in DIGITS:
                         # ignore this token, it's probably a percentage
                         continue
+                    if idx == 0 and len(msgid) == 1: 
+                       # Handle entries consisting solely of '%' to avoid
+                       # indexing beyond the end of the string while parsing
+                       # formatting placeholders.
+                       continue
                     if idx > -1 and msgid[idx-1] != "\\":
                         subidx = 0
                         if msgid[idx+1] == "(":
@@ -297,6 +302,11 @@ class Main:
                     if idx > 1 and msgstr[idx-1] == " " and msgstr[idx-2] in DIGITS:
                         # ignore this token, it's probably a percentage
                         continue
+                    if idx == 0 and len(msgstr) == 1: 
+                       # Handle entries consisting solely of '%' to avoid
+                       # indexing beyond the end of the string while parsing
+                       # formatting placeholders.
+                       continue
                     if idx > -1 and msgstr[idx-1] != "\\":
                         subidx = 0
                         if msgstr[idx+1] == "(":
@@ -321,7 +331,7 @@ class Main:
                                     break
             except Exception as e:
                 print("Error parsing msgstr at index %d: %s" % (idx, e))
-
+                
         for keyword in ["5%", "0%"]:
             if keyword in msgid:
                 # Ignore percentages


### PR DESCRIPTION
Fixes issue #28 
Now there are no errors coming in the terminal when there is lone % value. 
The issue talks about the Success Message as well - if there are no errors. 
Have left it out for now, in case, it is intentional to have no message for the users if there are no issues.

Thank you